### PR TITLE
Yosys: do not optimize designs during evaluation

### DIFF
--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -776,7 +776,8 @@ def make_pb_type(
                     flatten=False,
                     aig=False,
                     mode=smode,
-                    module_with_mode=mod.name
+                    module_with_mode=mod.name,
+                    noopt=True
                 )
             )
             mode_mod = mode_yj.module(mod.name)
@@ -817,7 +818,7 @@ def vlog_to_pbtype(infiles, outfile, top=None):
     iname = os.path.basename(infiles[0])
 
     run.add_define("PB_TYPE")
-    vjson = run.vlog_to_json(infiles, flatten=False, aig=False)
+    vjson = run.vlog_to_json(infiles, flatten=False, aig=False, noopt=True)
     yj = YosysJSON(vjson)
 
     if top is not None:

--- a/v2x/yosys/run.py
+++ b/v2x/yosys/run.py
@@ -122,7 +122,8 @@ def script(script, infiles=[]):
 
 
 def vlog_to_json(
-        infiles, flatten=False, aig=False, mode=None, module_with_mode=None
+        infiles, flatten=False, aig=False, mode=None, module_with_mode=None,
+        noopt=False
 ):
     """
     Convert Verilog to a JSON representation using Yosys
@@ -136,13 +137,16 @@ def vlog_to_json(
            set the value of the MODE parameter
     module_with_mode : the name of the module to apply `mode` to
     """
-    prep_opts = "-flatten" if flatten else ""
+    if noopt:
+        command = "proc; {}".format("flatten" if flatten else "")
+    else:
+        command = "prep {}".format("-flatten" if flatten else "")
     json_opts = "-aig" if aig else ""
     if mode is not None:
         mode_str = 'chparam -set MODE "{}" {}; '.format(mode, module_with_mode)
     else:
         mode_str = ""
-    cmds = "{}prep {}; write_json {}".format(mode_str, prep_opts, json_opts)
+    cmds = "{}{}; write_json {}".format(mode_str, command, json_opts)
     j = utils.strip_yosys_json(commands(cmds, infiles))
     """with open('dump.json', 'w') as dbg:
         print(j,file=dbg)"""


### PR DESCRIPTION
This PR add a possibility to disable Yosys optimization during design evaluation. This is required to correctly handle output buffers models. Those models have inputs, but no outputs. Yosys removes such cells during optimization.