### PR TITLE
Reworked net attribute retrieval

### DIFF
--- a/tests/net_attr/README.md
+++ b/tests/net_attr/README.md
@@ -1,3 +1,0 @@
-# Test for multiple occurrence of the same numerical net id in the "netnames" list.
-
-When connecting a singal through multiple wires Yosys assigns name of each of them to the same net id. Such a case triggered a bug in V2X causing it to crash. This test verifies that the reworked handling of "netnames" in V2X behaves properly.

--- a/tests/net_attr/README.md
+++ b/tests/net_attr/README.md
@@ -1,0 +1,3 @@
+# Test for multiple occurrence of the same numerical net id in the "netnames" list.
+
+When connecting a singal through multiple wires Yosys assigns name of each of them to the same net id. Such a case triggered a bug in V2X causing it to crash. This test verifies that the reworked handling of "netnames" in V2X behaves properly.

--- a/tests/net_attr/README.rst
+++ b/tests/net_attr/README.rst
@@ -1,0 +1,4 @@
+Test for multiple occurrence of the same numerical net id in the "netnames" list.
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+When connecting a signal through multiple wires Yosys assigns name of each of them to the same net id. Such a case triggered a bug in V2X causing it to crash. This test verifies that the reworked handling of "netnames" in V2X behaves properly.

--- a/tests/net_attr/README.rst
+++ b/tests/net_attr/README.rst
@@ -1,4 +1,4 @@
-Test for multiple occurrence of the same numerical net id in the "netnames" list.
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+Test for handling nets consisting of multiple wires
++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-When connecting a signal through multiple wires Yosys assigns name of each of them to the same net id. Such a case triggered a bug in V2X causing it to crash. This test verifies that the reworked handling of "netnames" in V2X behaves properly.
+This test verifies correct handling of nets that pass through multiple wires. In such cases Yosys assigns multiple names to that net.

--- a/tests/net_attr/child/child.model.xml
+++ b/tests/net_attr/child/child.model.xml
@@ -1,0 +1,10 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="CHILD">
+    <input_ports>
+      <port name="I"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/net_attr/child/child.pb_type.xml
+++ b/tests/net_attr/child/child.pb_type.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="CHILD" num_pb="1">
+  <blif_model>.subckt CHILD</blif_model>
+  <input name="I" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+</pb_type>

--- a/tests/net_attr/child/child.sim.v
+++ b/tests/net_attr/child/child.sim.v
@@ -1,0 +1,7 @@
+(* whitebox *)
+module CHILD(
+    input  wire I,
+    output wire O
+);
+
+endmodule

--- a/tests/net_attr/child/child.sim.v
+++ b/tests/net_attr/child/child.sim.v
@@ -1,4 +1,3 @@
-(* whitebox *)
 module CHILD(
     input  wire I,
     output wire O

--- a/tests/net_attr/golden.model.xml
+++ b/tests/net_attr/golden.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="./child/child.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/net_attr/golden.pb_type.xml
+++ b/tests/net_attr/golden.pb_type.xml
@@ -1,0 +1,19 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="PARENT" num_pb="1">
+  <input name="I" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+  <pb_type name="child" num_pb="1">
+    <!--old_name CHILD-->
+    <xi:include href="./child/child.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+  </pb_type>
+  <interconnect>
+    <direct>
+      <port name="I" type="input"/>
+      <port from="child" name="I" type="output"/>
+    </direct>
+    <direct>
+      <port from="child" name="O" type="input"/>
+      <port name="O" type="output"/>
+    </direct>
+  </interconnect>
+</pb_type>

--- a/tests/net_attr/parent.sim.v
+++ b/tests/net_attr/parent.sim.v
@@ -1,0 +1,15 @@
+`include "./child/child.sim.v"
+
+module PARENT(
+    input  wire I,
+    output wire O
+);
+
+    wire hop1 = I;
+
+    CHILD child (
+    .I(hop1),
+    .O(O)
+    );
+
+endmodule

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -212,7 +212,7 @@ def net_and_pin_attrs(yj, mod, driver: CellPin, sink: CellPin, netid: int):
         smod = yj.module(sink_type)
         potential_attrs.append(filter_src(smod.port_attrs(sink_pin)))
 
-    net_attrs = filter_src(mod.net_attrs(mod.net_name(netid)))
+    net_attrs = filter_src(mod.net_attrs_by_netid(netid))
     copy_attrs(net_attrs, potential_attrs)
     return net_attrs
 


### PR DESCRIPTION
Reworked net attribute retrieval to handle case when there are more than one wires per net. In such cases Yosys provided multiple net names per net id.