### PR TITLE
Added NO_COMB annotation.

### DIFF
--- a/tests/no_comb/README.rst
+++ b/tests/no_comb/README.rst
@@ -1,0 +1,6 @@
+Forced input to be non-combinational
+++++++++++++++++++++++++++++++++++++
+
+In some cases `vlog_to_model` incorrectly detects sequential signals as combinational (such as a FF with enable signal).
+
+A `NO_COMB` attribute is provided to specifically force an input to be non-combinational.

--- a/tests/no_comb/ff.sim.v
+++ b/tests/no_comb/ff.sim.v
@@ -1,0 +1,22 @@
+(* whitebox *)
+module FF(clk, D, S, R, E, Q);
+	input wire clk;
+	(* SETUP="clk 10e-12" *) (* NO_COMB *)
+	input wire D;
+	(* SETUP="clk 10e-12" *) (* NO_COMB *)
+	input wire E;
+	(* SETUP="clk 10e-12" *) (* NO_COMB *)
+	input wire S;
+	(* SETUP="clk 10e-12" *) (* NO_COMB *)
+	input wire R;
+	(* CLK_TO_Q = "clk 10e-12" *)
+	output reg Q;
+	always @(posedge clk or posedge S or posedge R) begin
+		if (S)
+			Q <= 1'b1;
+		else if (R)
+			Q <= 1'b0;
+		else if (E)
+			Q <= D;
+	end
+endmodule

--- a/tests/no_comb/golden.model.xml
+++ b/tests/no_comb/golden.model.xml
@@ -1,0 +1,14 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="FF">
+    <input_ports>
+      <port clock="clk" name="D"/>
+      <port clock="clk" name="E"/>
+      <port clock="clk" name="R"/>
+      <port clock="clk" name="S"/>
+      <port is_clock="1" name="clk"/>
+    </input_ports>
+    <output_ports>
+      <port clock="clk" name="Q"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/no_comb/golden.pb_type.xml
+++ b/tests/no_comb/golden.pb_type.xml
@@ -1,0 +1,15 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="FF" num_pb="1">
+  <blif_model>.subckt FF</blif_model>
+  <clock name="clk" num_pins="1"/>
+  <input name="D" num_pins="1"/>
+  <input name="E" num_pins="1"/>
+  <input name="R" num_pins="1"/>
+  <input name="S" num_pins="1"/>
+  <output name="Q" num_pins="1"/>
+  <T_setup clock="clk" port="D" value="10e-12"/>
+  <T_setup clock="clk" port="E" value="10e-12"/>
+  <T_clock_to_Q clock="clk" max="10e-12" port="Q"/>
+  <T_setup clock="clk" port="R" value="10e-12"/>
+  <T_setup clock="clk" port="S" value="10e-12"/>
+</pb_type>

--- a/tests/no_comb/output.xml
+++ b/tests/no_comb/output.xml
@@ -1,0 +1,14 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="FF">
+    <input_ports>
+      <port clock="clk" name="D"/>
+      <port clock="clk" name="E"/>
+      <port clock="clk" name="R"/>
+      <port clock="clk" name="S"/>
+      <port is_clock="1" name="clk"/>
+    </input_ports>
+    <output_ports>
+      <port clock="clk" name="Q"/>
+    </output_ports>
+  </model>
+</models>

--- a/v2x/vlog_to_model.py
+++ b/v2x/vlog_to_model.py
@@ -172,6 +172,7 @@ def vlog_to_model(infiles, includes, top, outfile=None):
             clocks = run.list_clocks(infiles, top)
 
             for name, width, bits, iodir in ports:
+                nocomb = tmod.net_attr(name, "NO_COMB")
                 attrs = dict(name=name)
                 sinks = run.get_combinational_sinks(infiles, top, name)
 
@@ -186,7 +187,7 @@ def vlog_to_model(infiles, includes, top, outfile=None):
                     attrs["is_clock"] = "1"
                 else:
                     clks = list()
-                    if len(sinks) > 0 and iodir == "input":
+                    if len(sinks) > 0 and iodir == "input" and nocomb is None:
                         attrs["combinational_sink_ports"] = " ".join(sinks)
                     for clk in clocks:
                         if is_clock_assoc(infiles, top, clk, name, iodir):


### PR DESCRIPTION
vlog_to_model in some cases (e.g. DFF with enable signal) incorrectly
detects signals as combinational. This annotation explicitly specifies
input as non-combinational.