### PR TITLE
Fixes for interconnect generation

### DIFF
--- a/tests/internal_conn/README.md
+++ b/tests/internal_conn/README.md
@@ -1,7 +1,0 @@
-# A test for cells with "passthrough" modes and direct pin-to-pin connections.
-
-This tests checks two cases:
-
-1. A cell may have some of its input pins connected directly to its output pins internally. In such a case that connection has to be expressed within its interconnect. This test does exactly that.
-2. Given a cell which has a "passthrough" mode with no child cells and a direct input to output connection, no pb_type for the "passthrough" mode should be generated. Moreover, the interconnect that holds the input to output connection should be defined directly undet the "mode" tag.
-

--- a/tests/internal_conn/README.md
+++ b/tests/internal_conn/README.md
@@ -1,0 +1,7 @@
+# A test for cells with "passthrough" modes and direct pin-to-pin connections.
+
+This tests checks two cases:
+
+1. A cell may have some of its input pins connected directly to its output pins internally. In such a case that connection has to be expressed within its interconnect. This test does exactly that.
+2. Given a cell which has a "passthrough" mode with no child cells and a direct input to output connection, no pb_type for the "passthrough" mode should be generated. Moreover, the interconnect that holds the input to output connection should be defined directly undet the "mode" tag.
+

--- a/tests/internal_conn/README.rst
+++ b/tests/internal_conn/README.rst
@@ -1,0 +1,9 @@
+A test for cells with "passthrough" modes and direct pin-to-pin connections.
+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+This tests checks two cases:
+
+1. A cell may have some of its input pins connected directly to its output pins internally. In such a case that connection has to be expressed within its interconnect. This test does exactly that.
+
+2. Given a cell which has a "passthrough" mode with no child cells and a direct input to output connection, no pb_type for the "passthrough" mode should be generated. Moreover, the interconnect that holds the input to output connection should be defined directly under the "mode" tag.
+

--- a/tests/internal_conn/README.rst
+++ b/tests/internal_conn/README.rst
@@ -1,9 +1,13 @@
 A test for cells with "passthrough" modes and direct pin-to-pin connections.
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-This tests checks two cases:
+This test demonstrates two use cases.
 
-1. A cell may have some of its input pins connected directly to its output pins internally. In such a case that connection has to be expressed within its interconnect. This test does exactly that.
+1. A non-primitive cell that has direct input to output connections inside.
 
-2. Given a cell which has a "passthrough" mode with no child cells and a direct input to output connection, no pb_type for the "passthrough" mode should be generated. Moreover, the interconnect that holds the input to output connection should be defined directly under the "mode" tag.
+    Such a cell has child cells that are connected to its ports. But it also contains direct connection(s) between its input and output ports. In such a case the direct connections have to be expressed within its interconnect along with regular connections to child cells.
 
+
+2. A cell with modes in which one of them is a "passthrough"
+
+    A passthrough mode defines a direct input to output connection and no child cells. In such a case no pb_type is to be generated for the "passthrough" mode. Instead, an interconnect defining the direect connection is placed directly under the "mode" tag.

--- a/tests/internal_conn/child/child.model.xml
+++ b/tests/internal_conn/child/child.model.xml
@@ -1,0 +1,10 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="CHILD">
+    <input_ports>
+      <port name="I"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/internal_conn/child/child.pb_type.xml
+++ b/tests/internal_conn/child/child.pb_type.xml
@@ -1,0 +1,6 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="CHILD">
+  <blif_model>.subckt CHILD</blif_model>
+  <input name="I" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+</pb_type>

--- a/tests/internal_conn/child/child.sim.v
+++ b/tests/internal_conn/child/child.sim.v
@@ -1,0 +1,7 @@
+(* blackbox *)
+module CHILD(
+  input  wire I,
+  output wire O
+);
+
+endmodule

--- a/tests/internal_conn/golden.model.xml
+++ b/tests/internal_conn/golden.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="child/child.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/internal_conn/golden.pb_type.xml
+++ b/tests/internal_conn/golden.pb_type.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="PARENT" num_pb="1">
+  <input name="I0" num_pins="1"/>
+  <input name="I1" num_pins="1"/>
+  <output name="O0" num_pins="1"/>
+  <output name="O1" num_pins="1"/>
+  <pb_type blif_model=".subckt CHILD" name="child" num_pb="1">
+    <input name="I" num_pins="1"/>
+    <output name="O" num_pins="1"/>
+  </pb_type>
+  <interconnect>
+    <direct input="child.O" name="PARENT-O0" output="PARENT.O0"/>
+    <direct input="PARENT.I1" name="PARENT-O1" output="PARENT.O1"/>
+    <direct input="PARENT.I0" name="child-I" output="child.I"/>
+  </interconnect>
+</pb_type>

--- a/tests/internal_conn/parent.sim.v
+++ b/tests/internal_conn/parent.sim.v
@@ -7,13 +7,12 @@ module PARENT (
   output wire O1
 );
 
-  // A child cell
   CHILD child (
   .I(I0),
   .O(O0)
   );
 
-  // An internal connection spanning ports of the PARENT cell.
+  // An direct connection from an input to the output pins.
   assign O1 = I1;
 
 endmodule

--- a/tests/internal_conn/parent.sim.v
+++ b/tests/internal_conn/parent.sim.v
@@ -1,0 +1,19 @@
+`include "./child/child.sim.v"
+
+module PARENT (
+  input  wire I0,
+  input  wire I1,
+  output wire O0,
+  output wire O1
+);
+
+  // A child cell was connected properly
+  CHILD child (
+  .I(I0),
+  .O(O0)
+  );
+
+  // Interconnect for this wasn't generated!
+  assign O1 = I1;
+
+endmodule

--- a/tests/internal_conn/parent.sim.v
+++ b/tests/internal_conn/parent.sim.v
@@ -7,13 +7,13 @@ module PARENT (
   output wire O1
 );
 
-  // A child cell was connected properly
+  // A child cell
   CHILD child (
   .I(I0),
   .O(O0)
   );
 
-  // Interconnect for this wasn't generated!
+  // An internal connection spanning ports of the PARENT cell.
   assign O1 = I1;
 
 endmodule

--- a/tests/modes/golden.model.xml
+++ b/tests/modes/golden.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="not/not.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/modes/golden.pb_type.xml
+++ b/tests/modes/golden.pb_type.xml
@@ -1,0 +1,43 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="INV">
+  <input name="I" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+  <mode name="PASSTHROUGH">
+    <interconnect>
+      <direct>
+        <port name="I" type="input"/>
+        <port name="O" type="output"/>
+      </direct>
+    </interconnect>
+  </mode>
+  <mode name="INVERT">
+    <pb_type num_pb="1" name="INVERT">
+      <input name="I" num_pins="1"/>
+      <output name="O" num_pins="1"/>
+      <pb_type num_pb="1" name="inverter">
+        <!--old_name NOT-->
+        <xi:include href="not/not.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+      </pb_type>
+      <interconnect>
+        <direct>
+          <port name="I" type="input"/>
+          <port name="I" type="output" from="inverter"/>
+        </direct>
+        <direct>
+          <port name="O" type="input" from="inverter"/>
+          <port name="O" type="output"/>
+        </direct>
+      </interconnect>
+    </pb_type>
+    <interconnect>
+      <direct>
+        <port name="I" type="input"/>
+        <port name="I" type="output" from="INVERT"/>
+      </direct>
+      <direct>
+        <port name="O" type="input" from="INVERT"/>
+        <port name="O" type="output"/>
+      </direct>
+    </interconnect>
+  </mode>
+</pb_type>

--- a/tests/modes/inv.sim.v
+++ b/tests/modes/inv.sim.v
@@ -5,7 +5,7 @@ module INV(I, O);
     input  wire I;
     output wire O;
 
-    parameter MODE="";
+    parameter MODE="PASSTHROUGH";
 
     // Passthrough (no inversion) mode
     generate if (MODE == "PASSTHROUGH") begin

--- a/tests/modes/inv.sim.v
+++ b/tests/modes/inv.sim.v
@@ -1,0 +1,19 @@
+`include "./not/not.sim.v"
+
+(* MODES="PASSTHROUGH;INVERT" *)
+module INV(I, O);
+    input  wire I;
+    output wire O;
+
+    parameter MODE="";
+
+    // Passthrough (no inversion) mode
+    generate if (MODE == "PASSTHROUGH") begin
+        assign O = I;
+
+    // Inversion with placeable inverter
+    end else if (MODE == "INVERT") begin
+        NOT inverter(I, O);
+
+    end endgenerate
+endmodule

--- a/tests/modes/not/not.model.xml
+++ b/tests/modes/not/not.model.xml
@@ -1,0 +1,10 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="NOT">
+    <input_ports>
+      <port name="I" combinational_sink_ports="O"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/modes/not/not.pb_type.xml
+++ b/tests/modes/not/not.pb_type.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="NOT">
+  <blif_model>.subckt NOT</blif_model>
+  <input name="I" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+  <delay_constant in_port="I" out_port="O" max="1e-10"/>
+</pb_type>

--- a/tests/modes/not/not.sim.v
+++ b/tests/modes/not/not.sim.v
@@ -1,0 +1,10 @@
+(* whitebox *)
+module NOT (I, O);
+
+  input  wire I;
+  (* DELAY_CONST_I="1e-10" *)
+  output wire O;
+
+  assign O = ~I;
+
+endmodule

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -376,7 +376,7 @@ def get_interconnects(yj, mod, mod_pname: str,
     return interconn
 
 
-def mode_interconnects(mod, mode_name) -> List[(CellPin)]:
+def mode_interconnects(mod, mode_name) -> Dict[CellPin, List[CellPin]]:
     interconn = {}
     for name, width, bits, iodir in mod.ports:
         if iodir == "input":

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -377,6 +377,16 @@ def get_interconnects(yj, mod, mod_pname: str,
 
 
 def mode_interconnects(mod, mode_name) -> Dict[CellPin, List[CellPin]]:
+    """
+    This function returns a definition of an interconnect used to connect
+    a child pb_type for the given mode with its parent pb_type that provides
+    the modes.
+
+    The returned dict is indexed by tuples containing source (driver) mode
+    names and pin names. Its values contain lists of sink modes and pin names
+    that are driven by the driver. If the mode name is None then the connection
+    refers to the parent pb_type.
+    """
     interconn = {}
     for name, width, bits, iodir in mod.ports:
         if iodir == "input":


### PR DESCRIPTION
This PR fixes two important bugs in interconnect generation:

1. Generation of connections between ports of the same pb_type

    V2X was completely missing generating interconnects for such cases. With this PR they are handled correctly

2. Handling a "pass-through" mode of a pb_type

    When defining a cell with a mode that does not have any children, the interconnect was generated incorrectly. This PR introduces a detection of such situations so no "empty" pb_type for the mode is generated. Istead, an iterconnect is generated that binds the passthrough connection ports.