### PR TITLE
Added support for defining IO cells

### DIFF
--- a/tests/io/README.md
+++ b/tests/io/README.md
@@ -1,0 +1,7 @@
+# Tests for modelling I/O primitives
+
+In VPR top-level I/O pins are represented using `.input` and `.output` BLIF models that are implemented by leaf pb_types. In order to model those using verilog you need to assing the specific `CLASS` attribute so the V2X would know that it has to use either `.input` or `.output` BLIF model for a cell.
+
+The I/O BLIF models are built-in into the VPR so there is no need for generating models for them. By specifying that a cell is of an I/O class the V2X won't generate model for it.
+
+This test verifies that functionality of the V2X.

--- a/tests/io/README.rst
+++ b/tests/io/README.rst
@@ -5,4 +5,3 @@ In VPR top-level I/O pins are represented using `.input` and `.output` BLIF mode
 
 The I/O BLIF models are built-in into the VPR so there is no need for generating models for them. By specifying that a cell is of an I/O class the V2X won't generate model for it.
 
-This test verifies that functionality of the V2X.

--- a/tests/io/README.rst
+++ b/tests/io/README.rst
@@ -1,4 +1,5 @@
-# Tests for modelling I/O primitives
+Tests for modelling I/O primitives
+++++++++++++++++++++++++++++++++++
 
 In VPR top-level I/O pins are represented using `.input` and `.output` BLIF models that are implemented by leaf pb_types. In order to model those using verilog you need to assing the specific `CLASS` attribute so the V2X would know that it has to use either `.input` or `.output` BLIF model for a cell.
 

--- a/tests/io/input/golden.model.xml
+++ b/tests/io/input/golden.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!--this file is intentionally left blank-->
+</models>

--- a/tests/io/input/golden.pb_type.xml
+++ b/tests/io/input/golden.pb_type.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="IPAD" num_pb="1">
+  <blif_model>.input</blif_model>
+  <output name="inpad" num_pins="1"/>
+</pb_type>

--- a/tests/io/input/ipad.sim.v
+++ b/tests/io/input/ipad.sim.v
@@ -1,0 +1,5 @@
+(* CLASS="input" *)
+module IPAD(inpad);
+    output wire inpad;
+
+endmodule

--- a/tests/io/output/golden.model.xml
+++ b/tests/io/output/golden.model.xml
@@ -1,0 +1,3 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!--this file is intentionally left blank-->
+</models>

--- a/tests/io/output/golden.pb_type.xml
+++ b/tests/io/output/golden.pb_type.xml
@@ -1,0 +1,5 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="OPAD" num_pb="1">
+  <blif_model>.output</blif_model>
+  <input name="outpad" num_pins="1"/>
+</pb_type>

--- a/tests/io/output/opad.sim.v
+++ b/tests/io/output/opad.sim.v
@@ -1,0 +1,5 @@
+(* CLASS="output" *)
+module OPAD(outpad);
+    input  wire outpad;
+
+endmodule

--- a/v2x/vlog_to_model.py
+++ b/v2x/vlog_to_model.py
@@ -162,7 +162,7 @@ def vlog_to_model(infiles, includes, top, outfile=None):
         ), "Leaf model names should be all uppercase!"
         modclass = tmod.attr("CLASS", "")
 
-        if modclass not in ("lut", "routing", "flipflop"):
+        if modclass not in ("input", "output", "lut", "routing", "flipflop"):
             model_xml = ET.SubElement(models_xml, "model", {'name': topname})
             ports = tmod.ports
 

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -9,8 +9,8 @@ The following are allowed on a top level module:
     This will also set the BLIF model to be `.subckt <name>` unless CLASS is
     also specified.
 
-    - `(* CLASS="lut|routing|mux|flipflop|mem" *)` : specify the class of an
-    given instance.
+    - `(* CLASS="input|output|lut|routing|mux|flipflop|mem" *)` : specify
+    the class of an given instance.
 
     - `(* MODES="mode1; mode2; ..." *)` : specify that the module has more
     than one functional mode, each with a given name. The module will be
@@ -715,7 +715,11 @@ def make_pb_type(
     ), "Model name should be uppercase. {}".format(model_name)
     mod_cls = mod.CLASS
     if mod_cls is not None:
-        if mod_cls == "lut":
+        if mod_cls == "input":
+            pb_attrs["blif_model"] = ".input"
+        elif mod_cls == "output":
+            pb_attrs["blif_model"] = ".output"
+        elif mod_cls == "lut":
             pb_attrs["blif_model"] = ".names"
             pb_attrs["class"] = "lut"
         elif mod_cls == "routing":


### PR DESCRIPTION
IO cells are defined by `.input` and `.output` BLIF models. This PR adds support for new `CLASS` types  that allow a cell to be converted to a top-level pb_type with `.input` or `.output` BLIF model.