### PR TITLE
Fixed dependency specification in setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 lxml
 pyjson
+-e git://github.com/SymbiFlow/vtr-xml-utils#egg=vtr-xml-utils

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,10 @@ setuptools.setup(
     install_requires=[
         'lxml',
         'pyjson',
-        'vtr_xml_utils @ git+https://github.com/Symbiflow/vtr-xml-utils',
+        'vtr-xml-utils'
+    ],
+    dependency_links=[
+        'https://github.com/Symbiflow/vtr-xml-utils/tarball/master#egg=vtr-xml-utils-0.0.1'
     ],
     setup_requires=["pytest-runner"],
     tests_require=[

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,11 @@ setuptools.setup(
     install_requires=[
         'lxml',
         'pyjson',
-        'vtr-xml-utils'
+        'vtr_xml_utils @ git+https://github.com/Symbiflow/vtr-xml-utils'
     ],
     dependency_links=[
-        'https://github.com/Symbiflow/vtr-xml-utils/tarball/master#egg=vtr-xml-utils-0.0.1'
+        'https://github.com/Symbiflow/vtr-xml-utils/tarball/'
+        'master#egg=vtr-xml-utils-0.0.1'
     ],
     setup_requires=["pytest-runner"],
     tests_require=[

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,6 @@ deps =
     # readme_renderer
     flake8
     pytest
-    lxml
 commands =
     check-manifest --ignore tox.ini,tests*
     # This repository uses a Markdown long_description, so the -r flag to


### PR DESCRIPTION
This PR fixes the external dependency from `vtr_xml_utils` so that Python setuptools can download and install it correctly.