### PR TITLE
Enchance clock detection

### DIFF
--- a/tests/clocks/README.md
+++ b/tests/clocks/README.md
@@ -1,14 +1,14 @@
 # `clocks` tests
 
 This directory contains test for the clock detection functionality for the
-`v2x_to_model.py` tool.
+`vlog_to_model.py` and `vlog_to_pbtype.py` tool.
 
 
 ## Detection of clock signals
 
- - [ ] Signal is named `clk`.
- - [ ] Signal has `clk` in the name.
- - [ ] Manually set via the `(* CLOCK *)` Verilog attribute.
+ - [ ] Signal name matches the regexp `[a-z_]*clk[a-z0-9]*$`
+ - [ ] Manually set via the `(* CLOCK *)` or `(* CLOCK=1 *)` Verilog attribute.
+ - [ ] Manually cleared via the `(* CLOCK=0 *)` Verilog attribute.
  - [ ] Signal drives synchronous logic (IE flipflop).
  - [ ] Detection in recursive module includes.
 

--- a/tests/clocks/input_attr_not_clock/block.sim.v
+++ b/tests/clocks/input_attr_not_clock/block.sim.v
@@ -5,13 +5,13 @@
  */
 module BLOCK(a, b, c);
     (* CLOCK=0 *)
-	input wire a;
-	input wire b;
-	output wire c;
-
-	reg r;
-	always @ ( posedge a ) begin
-		r <= b;
-	end
-	assign c = r;
+    input wire a;
+    input wire b;
+    output wire c;
+    
+    reg r;
+    always @ ( posedge a ) begin
+    	r <= b;
+    end
+    assign c = r;
 endmodule

--- a/tests/clocks/input_attr_not_clock/block.sim.v
+++ b/tests/clocks/input_attr_not_clock/block.sim.v
@@ -1,0 +1,17 @@
+/*
+ * `input wire a` should be detected as a clock because it drives the flip
+ * flop. However, it has the attribute CLOCK set to 0 which should force it
+ * to be a regular input.
+ */
+module BLOCK(a, b, c);
+    (* CLOCK=0 *)
+	input wire a;
+	input wire b;
+	output wire c;
+
+	reg r;
+	always @ ( posedge a ) begin
+		r <= b;
+	end
+	assign c = r;
+endmodule

--- a/tests/clocks/input_attr_not_clock/golden.model.xml
+++ b/tests/clocks/input_attr_not_clock/golden.model.xml
@@ -1,0 +1,11 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="BLOCK">
+    <input_ports>
+      <port clock="a" combinational_sink_ports="c" name="a"/>
+      <port clock="a" name="b"/>
+    </input_ports>
+    <output_ports>
+      <port clock="a" name="c"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/clocks/input_attr_not_clock/golden.pb_type.xml
+++ b/tests/clocks/input_attr_not_clock/golden.pb_type.xml
@@ -1,0 +1,7 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLOCK" num_pb="1">
+  <blif_model>.subckt BLOCK</blif_model>
+  <input name="a" num_pins="1"/>
+  <input name="b" num_pins="1"/>
+  <output name="c" num_pins="1"/>
+</pb_type>

--- a/tests/clocks/input_named_regex/block.sim.v
+++ b/tests/clocks/input_named_regex/block.sim.v
@@ -1,0 +1,14 @@
+(* whitebox *)
+module BLOCK(
+    input  wire clk,
+    input  wire Clk,
+    input  wire CLK,
+    input  wire clkX,
+    input  wire clkBus,
+    input  wire sys_clk,
+    input  wire sys_clk10,
+    input  wire regular_input,
+    output wire o
+);
+
+endmodule

--- a/tests/clocks/input_named_regex/golden.model.xml
+++ b/tests/clocks/input_named_regex/golden.model.xml
@@ -1,0 +1,17 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="BLOCK">
+    <input_ports>
+      <port is_clock="1" name="CLK"/>
+      <port is_clock="1" name="Clk"/>
+      <port is_clock="1" name="clk"/>
+      <port is_clock="1" name="clkBus"/>
+      <port is_clock="1" name="clkX"/>
+      <port name="regular_input"/>
+      <port is_clock="1" name="sys_clk"/>
+      <port is_clock="1" name="sys_clk10"/>
+    </input_ports>
+    <output_ports>
+      <port name="o"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/clocks/input_named_regex/golden.pb_type.xml
+++ b/tests/clocks/input_named_regex/golden.pb_type.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="BLOCK" num_pb="1">
+  <blif_model>.subckt BLOCK</blif_model>
+  <clock name="CLK" num_pins="1"/>
+  <clock name="Clk" num_pins="1"/>
+  <clock name="clk" num_pins="1"/>
+  <clock name="clkBus" num_pins="1"/>
+  <clock name="clkX" num_pins="1"/>
+  <clock name="sys_clk" num_pins="1"/>
+  <clock name="sys_clk10" num_pins="1"/>
+  <input name="regular_input" num_pins="1"/>
+  <output name="o" num_pins="1"/>
+</pb_type>

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -819,6 +819,12 @@ def make_pb_type(
         port_attrs = mod.port_attrs(name)
 
         is_clock = utils.is_clock_name(name)
+
+        # In pb_type "clock" ports can be only inputs. Clock outputs must
+        # be declared as "output".
+        if iodir == "output":
+            is_clock = False
+
         if "CLOCK" in port_attrs:
             is_clock = int(port_attrs["CLOCK"]) != 0
 

--- a/v2x/yosys/run.py
+++ b/v2x/yosys/run.py
@@ -236,7 +236,7 @@ def list_clocks(infiles, module):
     """
     return do_select(
         infiles, module,
-        "c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] a:CLOCK=1 %u c:* %d x:* %i"
+        "c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] c:* %d x:* %i"
     )
 
 

--- a/v2x/yosys/utils.py
+++ b/v2x/yosys/utils.py
@@ -1,11 +1,22 @@
 #!/usr/bin/env python3
 import re
-"""The JSON Yosys outputs isn't acutally compliant JSON, as it contains C-style
-comments. These must be stripped."""
+
+CLOCK_NAME_REGEX = re.compile(r"[a-z_]*clk[a-z0-9]*$")
 
 
 def strip_yosys_json(text):
+    """The JSON Yosys outputs isn't acutally compliant JSON, as it contains C-style
+    comments. These must be stripped."""
     stripped = re.sub(r'\\\n', '', text)
     stripped = re.sub(r'//.*\n', '\n', stripped)
     stripped = re.sub(r'/\*.*\*/', '', stripped)
     return stripped
+
+
+def is_clock_name(name):
+    """
+    Returns true if the port name correspond to a clock according to arbitrary
+    regular expressions.
+    """
+    match = CLOCK_NAME_REGEX.match(name.lower())
+    return match is not None

--- a/v2x/yosys/utils.py
+++ b/v2x/yosys/utils.py
@@ -17,6 +17,25 @@ def is_clock_name(name):
     """
     Returns true if the port name correspond to a clock according to arbitrary
     regular expressions.
+
+    >>> is_clock_name("data")
+    False
+    >>> is_clock_name("clk")
+    True
+    >>> is_clock_name("Clk")
+    True
+    >>> is_clock_name("Clk_Rst0")
+    False
+    >>> is_clock_name("Data_clk")
+    True
+    >>> is_clock_name("clk99")
+    True
+    >>> is_clock_name("bus_clk99")
+    True
+    >>> is_clock_name("busclk15")
+    True
+    >>> is_clock_name("clkb")
+    True
     """
     match = CLOCK_NAME_REGEX.match(name.lower())
     return match is not None


### PR DESCRIPTION
This PR improves clock detection in V2X:
- Apart from being detected by Yosys, clock signals are also identified by port names according to the regex (lowercase): `[a-z_]*clk[a-z0-9]*$`.
- The port attribute `CLOCK` can now force a port to non-clock when its set to 0, like: `(* CLOCK=0 *)`
- Whether a port is a clock or not is now consistent among the model and the pb_type.
- Clock outputs are defined as regular outputs in pb_type (VPR requires that).

I've also added/augmented tests.