### PR TITLE
Explicit combinational sink list

### DIFF
--- a/tests/comb_sinks/README.rst
+++ b/tests/comb_sinks/README.rst
@@ -1,0 +1,6 @@
+Explicit combinational sink list
+++++++++++++++++++++++++++++++++
+
+This is an example of modeling a clock buffer which has both clock inputs and outputs. According to the "Primitive Block Timing Modeling Tutorial" section "Clock Buffers & Muxes" of the VTR manual, a clock buffer or a clock mux has to have its outputs(s) as combinational sinks of clock input(s). This contradicts with how regular sequential blocks (like flip-flops) has to be modeled. Therefore when modeling a clock buffer with V2X its clock input must have explicitly given cobinational sinks which are clock outputs.
+
+For that there is the `COMB_SINKS` attribute which has to be applied to an input port. It should be assigned a string containing space separated list of port names that should be treated as combinational sinks of the input.

--- a/tests/comb_sinks/gmux.sim.v
+++ b/tests/comb_sinks/gmux.sim.v
@@ -1,0 +1,27 @@
+// A model of a clock multiplexer with two clock inputs, one clock output and
+// a select input.
+
+(* whitebox *)
+module GMUX (IP, IC, IS0, IZ);
+
+    // 1st clock input
+    (* CLOCK *)
+    (* COMB_SINKS="IZ" *)
+    input  wire IP;
+
+    // 2nd clock input
+    (* CLOCK *)
+    (* COMB_SINKS="IZ" *)
+    input  wire IC;
+
+    // Select input
+    input  wire IS0;
+
+    // Clock output (has to be defined as a regular output port)
+    output wire IZ;
+
+
+    // Behavioral model:
+    assign IZ = IS0 ? IC : IP;
+
+endmodule

--- a/tests/comb_sinks/golden.model.xml
+++ b/tests/comb_sinks/golden.model.xml
@@ -1,0 +1,12 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="GMUX">
+    <input_ports>
+      <port combinational_sink_ports="IZ" is_clock="1" name="IC"/>
+      <port combinational_sink_ports="IZ" is_clock="1" name="IP"/>
+      <port combinational_sink_ports="IZ" name="IS0"/>
+    </input_ports>
+    <output_ports>
+      <port name="IZ"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/comb_sinks/golden.pb_type.xml
+++ b/tests/comb_sinks/golden.pb_type.xml
@@ -1,0 +1,8 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="GMUX" num_pb="1">
+  <blif_model>.subckt GMUX</blif_model>
+  <clock name="IC" num_pins="1"/>
+  <clock name="IP" num_pins="1"/>
+  <input name="IS0" num_pins="1"/>
+  <output name="IZ" num_pins="1"/>
+</pb_type>


### PR DESCRIPTION
When modeling a clock buffer/mux, its clock output(s) must be combinational sinks of clock input(s). That's according to the VTR manual.

This contradicts with how currently v2x works - it removes comb. sinks from all clock inputs as they must not be specified for flip-flop like models.

This PR adds a way to explicitly provide a list of combinational sinks for an input port thus making modeling of clock gates possible. There is a one new test case added for that.