### PR TITLE
Allow docs/Makefile to be portable

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -5,11 +5,26 @@ MAKEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 # You can set these variables from the command line.
 SPHINXOPTS      =
-SPHINXBUILD     = [ -e env/bin/activate ] && source env/bin/activate; sphinx-build
-SPHINXAUTOBUILD = [ -e env/bin/activate ] && source env/bin/activate; sphinx-autobuild
+SPHINXBUILD     = [ -e env/bin/activate ] && . env/bin/activate; sphinx-build
+SPHINXAUTOBUILD = [ -e env/bin/activate ] && . env/bin/activate; sphinx-autobuild
 SPHINXPROJ      = SymbiFlowV2X
 SOURCEDIR       = .
 BUILDDIR        = _build
+OSFLAG 				:=
+UNAME_S := $(shell uname -s)
+ifneq (, $(findstring Linux, $(UNAME_S)))
+	OSFLAG := Linux
+endif
+ifeq ($(UNAME_S), Darwin)
+	OSFLAG := MacOSX
+endif
+ifneq (, $(findstring Cygwin, $(UNAME_S)))
+	OSFLAG := Linux
+endif
+ifneq (, $(findstring MINGW, $(UNAME_S)))
+	OSFLAG := Linux
+endif
+
 
 # Put it first so that "make" without argument is like "make help".
 help:
@@ -21,18 +36,18 @@ livehtml:
 .PHONY: help livehtml Makefile
 
 
-env/Miniconda3-latest-Linux-x86_64.sh:
+env/Miniconda3:
 	mkdir env
-	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O env/Miniconda3-latest-Linux-x86_64.sh
-	chmod a+x env/Miniconda3-latest-Linux-x86_64.sh
+	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(OSFLAG)-x86_64.sh -O env/Miniconda3-latest-$(OSFLAG)-x86_64.sh
+	chmod a+x env/Miniconda3-latest-$(OSFLAG)-x86_64.sh
 
 env:
 	rm -rf env
-	make env/Miniconda3-latest-Linux-x86_64.sh
-	./env/Miniconda3-latest-Linux-x86_64.sh -p $(PWD)/env -b -f
-	source env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
-	source env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs
-	source env/bin/activate; conda env update --name base --file ./environment.yml
+	make env/Miniconda3
+	./env/Miniconda3-latest-$(OSFLAG)-x86_64.sh -p $(PWD)/env -b -f
+	. env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
+	. env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs
+	. env/bin/activate; conda env update --name base --file ./environment.yml
 
 .PHONY: env
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -37,14 +37,14 @@ livehtml:
 .PHONY: help livehtml Makefile
 
 
-env/Miniconda3:
+env/Miniconda3-latest-$(OSFLAG)-x86_64.sh:
 	mkdir env
 	wget https://repo.anaconda.com/miniconda/Miniconda3-latest-$(OSFLAG)-x86_64.sh -O env/Miniconda3-latest-$(OSFLAG)-x86_64.sh
 	chmod a+x env/Miniconda3-latest-$(OSFLAG)-x86_64.sh
 
 env:
 	rm -rf env
-	make env/Miniconda3
+	make env/Miniconda3-latest-$(OSFLAG)-x86_64.sh
 	./env/Miniconda3-latest-$(OSFLAG)-x86_64.sh -p $(PWD)/env -b -f
 	source env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
 	source env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,7 @@ SPHINXAUTOBUILD = [ -e env/bin/activate ] && . env/bin/activate; sphinx-autobuil
 SPHINXPROJ      = SymbiFlowV2X
 SOURCEDIR       = .
 BUILDDIR        = _build
-OSFLAG 				:=
+OSFLAG          =
 UNAME_S := $(shell uname -s)
 ifneq (, $(findstring Linux, $(UNAME_S)))
 	OSFLAG := Linux

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,12 +1,13 @@
 # Minimal makefile for Sphinx documentation
 #
 
+SHELL = /bin/bash
 MAKEDIR := $(dir $(lastword $(MAKEFILE_LIST)))
 
 # You can set these variables from the command line.
 SPHINXOPTS      =
-SPHINXBUILD     = [ -e env/bin/activate ] && . env/bin/activate; sphinx-build
-SPHINXAUTOBUILD = [ -e env/bin/activate ] && . env/bin/activate; sphinx-autobuild
+SPHINXBUILD     = [ -e env/bin/activate ] && source env/bin/activate; sphinx-build
+SPHINXAUTOBUILD = [ -e env/bin/activate ] && source env/bin/activate; sphinx-autobuild
 SPHINXPROJ      = SymbiFlowV2X
 SOURCEDIR       = .
 BUILDDIR        = _build
@@ -45,9 +46,9 @@ env:
 	rm -rf env
 	make env/Miniconda3
 	./env/Miniconda3-latest-$(OSFLAG)-x86_64.sh -p $(PWD)/env -b -f
-	. env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
-	. env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs
-	. env/bin/activate; conda env update --name base --file ./environment.yml
+	source env/bin/activate; conda config --system --add envs_dirs $(PWD)/env/envs
+	source env/bin/activate; conda config --system --add pkgs_dirs $(PWD)/env/pkgs
+	source env/bin/activate; conda env update --name base --file ./environment.yml
 
 .PHONY: env
 


### PR DESCRIPTION
Currently docs/Makefile is configured to download only the Linux version of Conda. This commit allows it to detect the operating system and download the corresponding Conda installer.

Additionally, `make` uses the sh shell which does not support the `source` command. This causes the commands that use `source` to fail on some systems that do not have the sh shell linked to something else (say dash).

I only added the MacOSX installer because I don't have a Windows machine to test on. Similarly, I've added detection for Cygwin and MINGW environments but have yet to test them as well, although I think they should work as expected.

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>