### PR TITLE
Add the readthedocs dependencies to environment.yml

### DIFF
--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -11,5 +11,11 @@ dependencies:
 - pygobject
 - yosys
 - netlistsvg
-- pip:                            # Packages installed from PyPI
+# ReadTheDoc dependencies
+- mock
+- pillow
+- sphinx
+- sphinx_rtd_theme
+# Packages installed from PyPI
+- pip:
   - -r file:requirements.txt


### PR DESCRIPTION
Potentially a solution to;
 - https://github.com/readthedocs/readthedocs.org/issues/6870

Hopefully fixes #43.

Signed-off-by: Tim 'mithro' Ansell <me@mith.ro>