### PR TITLE
Pin verilog-diagram to an older version to stop build from failing

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -13,7 +13,7 @@ sphinxcontrib-napoleon
 git+https://github.com/SymbiFlow/sphinxcontrib-markdown-symlinks.git#egg=markdown_code_symlinks
 
 # Verilog diagrams using Yosys + netlistsvg
-git+https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams.git#egg=sphinxcontrib-verilog-diagrams
+git+https://github.com/SymbiFlow/sphinxcontrib-verilog-diagrams.git@dca04723ec07209bd7be3e883e780ca9dd4f271e#egg=sphinxcontrib-verilog-diagrams
 
 # Module diagrams
 symbolator


### PR DESCRIPTION
This older version should be used until the yosys package in conda is updated to the upstream version, to stop the readthedocs build from failing.

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>