### PR TITLE
ci: Add scripts to check for necessary headers

### DIFF
--- a/.github/travis/check_license.sh
+++ b/.github/travis/check_license.sh
@@ -17,7 +17,8 @@ echo
 ERROR_FILES=""
 FILES_TO_CHECK=`find . \
     -type f \( -name '*.sh' -o -name '*.py' -o -name 'Makefile' -o -name '*.v' \) \
-    \( -not -path "*/*/__init__.py" -not -path "*/.*/*" -not -path "*/third_party/*" -not -path "*/env/*" \)`
+    \( -not -path "*/.*/*" -not -path "*/third_party/*" -not -path "*/env/*" \) \
+    \( -not -path "*/*/__init__.py" -not -path "./miniconda.sh" \)`
 
 for file in $FILES_TO_CHECK; do
     echo "Checking $file"

--- a/.github/travis/check_license.sh
+++ b/.github/travis/check_license.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
+
+echo
+echo "==========================="
+echo "Check SPDX identifier"
+echo "==========================="
+echo
+
+ERROR_FILES=""
+FILES_TO_CHECK=`find . \
+    -type f \( -name '*.sh' -o -name '*.py' -o -name 'Makefile' -o -name '*.v' \) \
+    \( -not -path "*/*/__init__.py" -not -path "*/.*/*" -not -path "*/third_party/*" -not -path "*/env/*" \)`
+
+for file in $FILES_TO_CHECK; do
+    echo "Checking $file"
+    grep -q "SPDX-License-Identifier" $file || ERROR_FILES="$ERROR_FILES $file"
+done
+
+if [ ! -z "$ERROR_FILES" ]; then
+    for file in $ERROR_FILES; do
+        echo "ERROR: $file does not have license information."
+    done
+    return 1
+fi
+
+echo
+echo "==========================="
+echo "Check third party LICENSE"
+echo "==========================="
+echo
+
+function check_if_submodule {
+    for submodule in `git submodule --quiet foreach 'echo $sm_path'`; do
+        if [ "$1" == "$submodule" ]; then
+            return 1
+        fi
+    done
+}
+
+THIRD_PARTY_DIRS=`ls -d third_party/*`
+ERROR_NO_LICENSE=""
+
+for dir in $THIRD_PARTY_DIRS; do
+    # Checks if we are not in a submodule
+    if check_if_submodule $dir; then
+        echo "Checking $dir"
+        [ -f $dir/LICENSE ] || ERROR_NO_LICENSE="$ERROR_NO_LICENSE $dir"
+    fi
+done
+
+if [ ! -z "$ERROR_NO_LICENSE" ]; then
+    for dir in $ERROR_NO_LICENSE; do
+        echo "ERROR: $dir does not have the LICENSE file."
+    done
+    return 1
+fi

--- a/.github/travis/check_python_script.sh
+++ b/.github/travis/check_python_script.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+
+echo
+echo "==================================="
+echo "Check python utf coding and shebang"
+echo "==================================="
+echo
+
+ERROR_FILES_SHEBANG=""
+ERROR_FILES_UTF_CODING=""
+FILES_TO_CHECK=`find . \
+    -type f \( -name '*.py' \) \
+    \( -not -path "*/.*/*" -not -path "*/third_party/*" -not -path "*/env/*" \)`
+
+for file in $FILES_TO_CHECK; do
+    echo "Checking $file"
+    grep -q "\#\!/usr/bin/env python3" $file || ERROR_FILES_SHEBANG="$ERROR_FILES_SHEBANG $file"
+    grep -q "\#.*coding: utf-8" $file || ERROR_FILES_UTF_CODING="$ERROR_FILES_UTF_CODING $file"
+done
+
+if [ ! -z "$ERROR_FILES_SHEBANG" ]; then
+    for file in $ERROR_FILES_SHEBANG; do
+        echo "ERROR: $file does not have the python3 shebang."
+    done
+    return 1
+fi
+
+if [ ! -z "$ERROR_FILES_UTF_CODING" ]; then
+    for file in $ERROR_FILES_UTF_CODING; do
+        echo "ERROR: $file does not have the utf encoding set."
+    done
+    return 1
+fi
+
+echo

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ matrix:
 install:
   - . prepareenv.sh
   - conda activate yosys-env
+  - source .github/travis/check_license.sh
+  - source .github/travis/check_python_script.sh
 
 script: tox
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,3 +1,11 @@
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
+
 # Minimal makefile for Sphinx documentation
 #
 

--- a/prepareenv.sh
+++ b/prepareenv.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
 
 pip install tox
 wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh

--- a/v2x/__init__.py
+++ b/v2x/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-

--- a/v2x/lib/__init__.py
+++ b/v2x/lib/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-

--- a/v2x/xmlinc/__init__.py
+++ b/v2x/xmlinc/__init__.py
@@ -1,0 +1,2 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-

--- a/v2x/yosys/__init__.py
+++ b/v2x/yosys/__init__.py
@@ -1,1 +1,2 @@
 #!/usr/bin/env python3
+# -*- coding: utf-8 -*-


### PR DESCRIPTION
Take the scripts by @acomodi from https://github.com/SymbiFlow/fpga-tool-perf/tree/f8d143b73f670eea5efdbe96f1236d82998c896e/.github/travis

Also fix files that fail the checks.

Currently `__init__.py` files are omitted from the checks since they are all empty.