### PR TITLE
docs: Change to use symbiflow's theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -124,7 +124,7 @@ todo_include_todos = True
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'sphinx_materialdesign_theme'
+html_theme = 'sphinx_symbiflow_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the
@@ -185,18 +185,6 @@ html_theme_options = {
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
-
-# Custom sidebar templates, must be a dictionary that maps document names
-# to template names.
-#
-# This is required for the alabaster theme
-# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
-html_sidebars = {
-    '**': [
-        'relations.html',  # needs 'show_related': True theme option to display
-        'searchbox.html',
-    ]
-}
 
 # -- Options for HTMLHelp output ------------------------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,4 @@
-sphinx_materialdesign_theme
+git+http://github.com/SymbiFlow/sphinx_materialdesign_theme.git@master#egg=sphinx_symbiflow_theme
 
 docutils
 sphinx


### PR DESCRIPTION
This was removed as it renders weirdly.

```
# Custom sidebar templates, must be a dictionary that maps document names
# to template names.
#
# This is required for the alabaster theme
# refs: http://alabaster.readthedocs.io/en/latest/installation.html#sidebars
html_sidebars = {
    '**': [
        'relations.html',  # needs 'show_related': True theme option to display
        'searchbox.html',
    ]
}
```

![image](https://user-images.githubusercontent.com/8130120/80868279-20385080-8ccc-11ea-94f9-9e6870944c37.png)

I don't think the material design theme currently supports this and we don't use it in the original docs anyways. Just not sure why it shows up when the theme is changed to our fork.

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>