### PR TITLE
docs: Use no-license directive

### DIFF
--- a/tests/clocks/dff_comb_one_clock/README.rst
+++ b/tests/clocks/dff_comb_one_clock/README.rst
@@ -11,9 +11,8 @@ The following shows a combinational logic design driven by a clock. ``input wire
 
 |
 
-.. literalinclude:: ../../../tests/clocks/dff_comb_one_clock/dff_comb_one_clock.sim.v
+.. no-license:: ../../../tests/clocks/dff_comb_one_clock/dff_comb_one_clock.sim.v
    :language: verilog
-   :start-after:  */
    :caption: tests/clocks/dff_comb_one_clock/dff_comb_one_clock.sim.v
 
 The ``is_clock`` attribute of the ``a`` port is set to 1, and the ports ``b``, ``c`` and ``d`` have their ``clock`` attribute set to ``a``.

--- a/tests/clocks/dff_one_clock/README.rst
+++ b/tests/clocks/dff_one_clock/README.rst
@@ -11,9 +11,8 @@ The following shows a simple D-flip flop driven by one clock. ``input wire a`` s
 
 |
 
-.. literalinclude:: ../../../tests/clocks/dff_one_clock/dff_one_clock.sim.v
+.. no-license:: ../../../tests/clocks/dff_one_clock/dff_one_clock.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/dff_one_clock/dff_one_clock.sim.v
 
 As you can see in the generated model, the ``is_clock`` attribute of the ``a`` port is set to 1, while the ``b`` and ``c`` ports have their ``clock`` attribute set to ``a``.

--- a/tests/clocks/dff_two_clocks/README.rst
+++ b/tests/clocks/dff_two_clocks/README.rst
@@ -11,9 +11,8 @@ D-Flipflop with two clocks
 
 |
 
-.. literalinclude:: ../../../tests/clocks/dff_two_clocks/dff_two_clocks.sim.v
+.. no-license:: ../../../tests/clocks/dff_two_clocks/dff_two_clocks.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/dff_two_clocks/dff_two_clocks.sim.v
 
 The ``is_clock`` attribute of the ``c1`` and ``c2`` ports are set to 1, and the ports ``a``, ``b``, ``c``, ``o1`` and ``o2`` have their ``clock`` attribute set to the respective clocks they are driven by.

--- a/tests/clocks/input_attr_clock/README.rst
+++ b/tests/clocks/input_attr_clock/README.rst
@@ -7,9 +7,8 @@ The following shows that ``input wire a`` is given the ``(* CLOCK *)`` attribute
 
 |
 
-.. literalinclude:: ../../../tests/clocks/input_attr_clock/input_attr_clock.sim.v
+.. no-license:: ../../../tests/clocks/input_attr_clock/input_attr_clock.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/input_attr_clock/input_attr_clock.sim.v
 
 As such, the ``is_clock`` attribute of the ``a`` port is set to 1.

--- a/tests/clocks/input_attr_not_clock/README.rst
+++ b/tests/clocks/input_attr_not_clock/README.rst
@@ -11,9 +11,8 @@ Force input as regular input by setting the CLOCK attribute
 
 |
 
-.. literalinclude:: ../../../tests/clocks/input_attr_not_clock/block.sim.v
+.. no-license:: ../../../tests/clocks/input_attr_not_clock/block.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/input_attr_not_clock/block.sim.v
 
 As such, the ``is_clock`` attribute of the ``a`` port is not set.

--- a/tests/clocks/input_named_clk/README.rst
+++ b/tests/clocks/input_named_clk/README.rst
@@ -7,9 +7,8 @@ An input wire can be set as a clock by assigning ``clk`` as its name.
 
 |
 
-.. literalinclude:: ../../../tests/clocks/input_named_clk/input_named_clk.sim.v
+.. no-license:: ../../../tests/clocks/input_named_clk/input_named_clk.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/input_named_clk/input_named_clk.sim.v
 
 As such, the ``is_clock`` attribute of the ``clk`` port is set to 1, without needing to set anything else in the verilog code.

--- a/tests/clocks/input_named_regex/README.rst
+++ b/tests/clocks/input_named_regex/README.rst
@@ -7,9 +7,8 @@ An input wire can be set as a clock by having ``clk`` in its name (case insensit
 
 |
 
-.. literalinclude:: ../../../tests/clocks/input_named_regex/block.sim.v
+.. no-license:: ../../../tests/clocks/input_named_regex/block.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/input_named_regex/block.sim.v
 
 As such, the ``is_clock`` attribute of wires with a variation of ``clk`` in their name is set to 1.

--- a/tests/clocks/multiple_inputs_named_clk/README.rst
+++ b/tests/clocks/multiple_inputs_named_clk/README.rst
@@ -7,9 +7,8 @@ Set inputs as clock by name (multiple clock inputs)
 
 |
 
-.. literalinclude:: ../../../tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
+.. no-license:: ../../../tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/multiple_inputs_named_clk/multiple_inputs_named_clk.sim.v
 
 As such, the ``is_clock`` attribute of the ``rdclk`` and ``wrclk`` ports are set to 1.

--- a/tests/clocks/multiple_outputs_named_clk/README.rst
+++ b/tests/clocks/multiple_outputs_named_clk/README.rst
@@ -7,9 +7,8 @@ Set outputs as clock by name (multiple clock outputs)
 
 |
 
-.. literalinclude:: ../../../tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
+.. no-license:: ../../../tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/multiple_outputs_named_clk/multiple_outputs_named_clk.sim.v
 
 As such, the ``is_clock`` attribute of the ``rdclk`` and ``wrclk`` ports are set to 1.

--- a/tests/clocks/output_attr_clock/README.rst
+++ b/tests/clocks/output_attr_clock/README.rst
@@ -7,9 +7,8 @@ The following shows that ``output wire o`` is given the ``(* CLOCK *)`` attribut
 
 |
 
-.. literalinclude:: ../../../tests/clocks/output_attr_clock/output_attr_clock.sim.v
+.. no-license:: ../../../tests/clocks/output_attr_clock/output_attr_clock.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/output_attr_clock/output_attr_clock.sim.v
 
 As such, the ``is_clock`` attribute of the ``o`` port is set to 1.

--- a/tests/clocks/output_named_clk/README.rst
+++ b/tests/clocks/output_named_clk/README.rst
@@ -7,9 +7,8 @@ An output wire can be set as a clock by assigning ``clk`` as its name.
 
 |
 
-.. literalinclude:: ../../../tests/clocks/output_named_clk/output_named_clk.sim.v
+.. no-license:: ../../../tests/clocks/output_named_clk/output_named_clk.sim.v
    :language: verilog
-   :start-after: */
    :caption: tests/clocks/output_named_clk/output_named_clk.sim.v
 
 As such, the ``is_clock`` attribute of the ``clk`` output port is set to 1.


### PR DESCRIPTION
Use the `no-license` directive provided by sphinxcontrib_verilog_diagrams instead of `literalinclude` with the `:startafter` option.

Side note, I realized the xml files in the tests/ directory don't have the copyright headers. Do they need it too?

Signed-off-by: Daniel Lim Wee Soong <weesoong.lim@gmail.com>