### PR TITLE
Yosys selection fix

### DIFF
--- a/conf/environment.yml
+++ b/conf/environment.yml
@@ -2,7 +2,7 @@ name: yosys-env
 channels:
   - symbiflow
 dependencies:
-  - yosys
+  - symbiflow-yosys
   - pip:
     - tox
     - flake8

--- a/v2x/vlog_to_model.py
+++ b/v2x/vlog_to_model.py
@@ -90,6 +90,14 @@ def is_registered_path(tmod, pin, pout):
 
 
 def vlog_to_model(infiles, includes, top, outfile=None):
+
+    # Check Yosys version
+    pfx = run.determine_select_prefix()
+    if pfx != "=":
+        print("ERROR The version of Yosys found is outdated and not supported"
+              " by V2X")
+        sys.exit(-1)
+
     iname = os.path.basename(infiles[0])
 
     if outfile is None:

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -910,6 +910,14 @@ def make_pb_type(
 
 
 def vlog_to_pbtype(infiles, outfile, top=None):
+
+    # Check Yosys version
+    pfx = run.determine_select_prefix()
+    if pfx != "=":
+        print("ERROR The version of Yosys found is outdated and not supported"
+              " by V2X")
+        sys.exit(-1)
+
     iname = os.path.basename(infiles[0])
 
     run.add_define("PB_TYPE")

--- a/v2x/yosys/run.py
+++ b/v2x/yosys/run.py
@@ -283,7 +283,7 @@ def get_combinational_sinks(infiles, module, innet):
     innet: Name of input net to find sinks of
     """
     return do_select(
-        infiles, module, "{} %co* o:* %i {} %d".format(innet, innet)
+        infiles, module, "={} %co* =o:* %i ={} %d".format(innet, innet)
     )
 
 
@@ -297,7 +297,7 @@ def list_clocks(infiles, module):
     """
     return do_select(
         infiles, module,
-        "c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] c:* %d x:* %i"
+        "=c:* %x:+[CLK]:+[clk]:+[clock]:+[CLOCK] =c:* %d =x:* %i"
     )
 
 
@@ -312,7 +312,7 @@ def get_clock_assoc_signals(infiles, module, clk):
     """
     return do_select(
         infiles, module,
-        "select -list {} %a %co* %x i:* o:* %u %i a:ASSOC_CLOCK={} %u {} %d".
+        "select -list ={} %a %co* %x =i:* =o:* %u %i =a:ASSOC_CLOCK={} %u ={} %d".
         format(clk, clk, clk)
     )
 
@@ -337,7 +337,7 @@ def get_related_output_for_input(infiles, module, signal):
     clk: Name of clock to find associated signals
     """
     return do_select(
-        infiles, module, "select -list w:*{} %a %co* o:* %i".format(signal)
+        infiles, module, "select -list =w:*{} %a %co* =o:* %i".format(signal)
     )
 
 
@@ -353,6 +353,6 @@ def get_related_inputs_for_input(infiles, module, signal):
     return [
         x for x in do_select(
             infiles, module,
-            "select -list w:*{} %a %co* %x i:* %i".format(signal)
+            "select -list =w:*{} %a %co* %x =i:* %i".format(signal)
         ) if x != signal
     ]


### PR DESCRIPTION
This PR changes the selection pattern syntax used for `select` commands. At some point the syntax was changed in upstream Yosys which made V2X crash. Moreover in this PR there is a piece of code that identifies which syntax is required for the version of Yosys being used. The correct syntax is chosen automatically.