### PR TITLE
CI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,4 +104,3 @@ venv.bak/
 .mypy_cache/
 
 *.sw*
-conda.tmp.yml

--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ venv.bak/
 .mypy_cache/
 
 *.sw*
+conda.tmp.yml

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: python
 
 python:
-  - 2.7
-  - 3.4
   - 3.5
   - 3.6
   - 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,16 @@
-language: minimal
+language: python
+
+python:
+  - 2.7
+    env: TOXENV=py27
+  - 3.4
+    env: TOXENV=py27
+  - 3.5
+    env: TOXENV=py27
+  - 3.6
+    env: TOXENV=py27
+  - 3.7
+    env: TOXENV=py27
 
 install:
   - source prepareenv.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,10 @@ language: python
 
 python:
   - 2.7
-    env: TOXENV=py27
   - 3.4
-    env: TOXENV=py27
   - 3.5
-    env: TOXENV=py27
   - 3.6
-    env: TOXENV=py27
   - 3.7
-    env: TOXENV=py27
 
 install:
   - source prepareenv.sh
@@ -20,7 +15,7 @@ install:
 script:
   - conda activate yosys-env
   - which tox
-  - tox
+  - TOXENV="py${TRAVIS_PYTHON_VERSION//./}" tox
 
 notifications:
   email: false

--- a/prepareenv.sh
+++ b/prepareenv.sh
@@ -16,4 +16,5 @@ conda config --set always_yes yes --set changeps1 no
 conda install -q setuptools
 conda update -q conda
 conda env create --file conf/environment.yml
+conda config --set env_prompt '({name})'
 conda activate yosys-env

--- a/tests/vtr/lutff-pair/golden.pb_type.xml
+++ b/tests/vtr/lutff-pair/golden.pb_type.xml
@@ -39,14 +39,14 @@
       <port from="lut" name="I[3]" type="output"/>
     </direct>
     <mux name="mux">
-      <port from="lut" name="O" type="input">
-        <metadata>
-          <meta name="fasm_mux">L</meta>
-        </metadata>
-      </port>
       <port from="ff" name="Q" type="input">
         <metadata>
           <meta name="fasm_mux">F</meta>
+        </metadata>
+      </port>
+      <port from="lut" name="O" type="input">
+        <metadata>
+          <meta name="fasm_mux">L</meta>
         </metadata>
       </port>
       <port name="O" type="output"/>

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     flake8
     pytest
 commands =
-    check-manifest --ignore tox.ini,tests*
+    check-manifest --ignore tox.ini,tests,*.pyc
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,8 @@ envlist = py{27,34,35,36,37}
 setenv =
     PYTHONPATH={toxinidir}/v2x
 basepython =
+    py27: python2.7
+    py34: python3.4
     py35: python3.5
     py36: python3.6
     py37: python3.7
@@ -16,6 +18,7 @@ deps =
     pytest
 commands =
     check-manifest --ignore tox.ini,tests,*.pyc
+    python --version
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.

--- a/tox.ini
+++ b/tox.ini
@@ -17,13 +17,14 @@ deps =
     flake8
     pytest
 commands =
-    check-manifest --ignore tox.ini,tests,*.pyc
+    check-manifest --ignore tox.ini,tests,*.pyc,*.swp
     python --version
     # This repository uses a Markdown long_description, so the -r flag to
     # `setup.py check` is not needed. If your project contains a README.rst,
     # use `python setup.py check -m -r -s` instead.
     python setup.py check -m -s
     flake8 .
+    pytest --doctest-modules -vv v2x
     pytest -vv
 [flake8]
 exclude = .tox,*.egg,build,data

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -268,10 +268,14 @@ def make_mux_conn(
 ) -> ET.Element:
 
     mux_xml = ET.SubElement(ic_xml, "mux", {"name": mux_name})
-    for mux_input, driver in mux_inputs.items():
+
+    keys = sorted(list(mux_inputs.keys()))
+    for mux_input, driver in [(k, mux_inputs[k],) for k in keys]:
         create_port(mux_xml, driver, "input", metadata={'fasm_mux': mux_input})
+
     assert len(mux_outputs) == 1, mux_outputs
-    for mux_pin, sinks in mux_outputs.items():
+    keys = sorted(list(mux_outputs.keys()))
+    for mux_pin, sinks in [(k, mux_outputs[k],) for k in keys]:
         assert len(sinks) == 1, sinks
         for sink_pin, path_attr in sinks:
             create_port(mux_xml, sink_pin, "output")


### PR DESCRIPTION
I've fixed some issues with Travis CI here:
- Added testing against all (almost all) requested Python versions
- Added running doctests for V2X (they weren't run)

Apart from that I've added sorting of interconnect mux inputs by name. This ensures that V2X output remains consistent among all python versions (especially for 3.5)