### PR TITLE
pb_type: fix addition of blif model to muxes

### DIFF
--- a/tests/mux_class/README.md
+++ b/tests/mux_class/README.md
@@ -1,0 +1,7 @@
+# Routing Mux tests
+
+This directory contains tests for the `v2x_to_model.py` and `v2x_to_pb_type` tools.
+
+## "mux" Modela Class
+
+ - [ ] modules that have the CLASS attribute defined as `mux` should contain the subckt attribute in the pb\_type.

--- a/tests/mux_class/golden.model.xml
+++ b/tests/mux_class/golden.model.xml
@@ -1,0 +1,12 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="MUX_MODEL_NAME">
+    <input_ports>
+      <port combinational_sink_ports="O" name="I0"/>
+      <port combinational_sink_ports="O" name="I1"/>
+      <port combinational_sink_ports="O" name="S"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/mux_class/golden.pb_type.xml
+++ b/tests/mux_class/golden.pb_type.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="MUX_CLASS">
+  <blif_model>.subckt MUX_MODEL_NAME</blif_model>
+  <input name="I0" num_pins="1"/>
+  <input name="I1" num_pins="1"/>
+  <input name="S" num_pins="1"/>
+  <output name="O" num_pins="1"/>
+  <delay_constant in_port="I0" out_port="O" max="1e-10"/>
+  <delay_constant in_port="I1" out_port="O" max="1e-10"/>
+  <delay_constant in_port="S" out_port="O" max="1e-10"/>
+</pb_type>

--- a/tests/mux_class/mux_class.sim.v
+++ b/tests/mux_class/mux_class.sim.v
@@ -1,4 +1,12 @@
-`default_nettype none
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Use of this source code is governed by a ISC-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/ISC
+ *
+ * SPDX-License-Identifier:	ISC
+ */
 
 (* CLASS="mux" *)
 (* MODEL_NAME="MUX_MODEL_NAME" *)

--- a/tests/mux_class/mux_class.sim.v
+++ b/tests/mux_class/mux_class.sim.v
@@ -1,0 +1,19 @@
+`default_nettype none
+
+(* CLASS="mux" *)
+(* MODEL_NAME="MUX_MODEL_NAME" *)
+(* whitebox *)
+module MUX_CLASS(I0, I1, S, O);
+
+	input wire I0;
+	input wire I1;
+
+	input wire S;
+
+	(* DELAY_CONST_I0 = "1e-10" *)
+	(* DELAY_CONST_I1 = "1e-10" *)
+	(* DELAY_CONST_S = "1e-10" *)
+	output wire O;
+
+	assign O = S ? I1 : I0;
+endmodule

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -787,7 +787,7 @@ def make_pb_type(
             # TODO: pb_attrs["class"] = "routing"
             pass
         elif mod_cls == "mux":
-            # TODO: ?
+            pb_attrs["blif_model"] = ".subckt " + model_name
             pass
         elif mod_cls == "flipflop":
             pb_attrs["blif_model"] = ".latch"


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

This PR solves an issue with the generation of the blif attribute for pb_types when the primitive class is defined as `mux`.