### PR TITLE
muxes: add name of routing mux as metadata prefix

### DIFF
--- a/tests/muxes/golden.pb_type.xml
+++ b/tests/muxes/golden.pb_type.xml
@@ -30,12 +30,12 @@
     <mux name="mux1">
       <port from="lboxa" name="O" type="input">
         <metadata>
-          <meta name="fasm_mux">I0</meta>
+          <meta name="fasm_mux">mux1.I0</meta>
         </metadata>
       </port>
       <port from="lboxb" name="O" type="input">
         <metadata>
-          <meta name="fasm_mux">I1</meta>
+          <meta name="fasm_mux">mux1.I1</meta>
         </metadata>
       </port>
       <port name="o1" type="output"/>
@@ -47,12 +47,12 @@
     <mux name="mux2">
       <port from="lboxa" name="O" type="input">
         <metadata>
-          <meta name="fasm_mux">I0</meta>
+          <meta name="fasm_mux">mux2.I0</meta>
         </metadata>
       </port>
       <port from="lboxc" name="O" type="input">
         <metadata>
-          <meta name="fasm_mux">I1</meta>
+          <meta name="fasm_mux">mux2.I1</meta>
         </metadata>
       </port>
       <port name="o2" type="output"/>

--- a/tests/vtr/lutff-pair/golden.pb_type.xml
+++ b/tests/vtr/lutff-pair/golden.pb_type.xml
@@ -41,12 +41,12 @@
     <mux name="mux">
       <port from="dff" name="Q" type="input">
         <metadata>
-          <meta name="fasm_mux">F</meta>
+          <meta name="fasm_mux">mux.F</meta>
         </metadata>
       </port>
       <port from="lut" name="O" type="input">
         <metadata>
-          <meta name="fasm_mux">L</meta>
+          <meta name="fasm_mux">mux.L</meta>
         </metadata>
       </port>
       <port name="O" type="output"/>

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -271,7 +271,8 @@ def make_mux_conn(
 
     keys = sorted(list(mux_inputs.keys()))
     for mux_input, driver in [(k, mux_inputs[k],) for k in keys]:
-        create_port(mux_xml, driver, "input", metadata={'fasm_mux': mux_input})
+        metadata = {'fasm_mux': '{}.{}'.format(mux_name, mux_input)}
+        create_port(mux_xml, driver, "input", metadata=metadata)
 
     assert len(mux_outputs) == 1, mux_outputs
     keys = sorted(list(mux_outputs.keys()))


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Without this change, the information on which routing mux has a specific input selected is lost.

Output before:

```xml
<mux input="COMMON_SLICE.AX COMMON_SLICE.A5LUT_O5 COMMON_SLICE.A6LUT_O6" name="AFFMUX1" output="SLICE_FF.D[15]">
    <metadata>
        <meta name="fasm_mux">
            COMMON_SLICE.AX : BYP
            COMMON_SLICE.A5LUT_O5 : D5
            COMMON_SLICE.A6LUT_O6 : D6
        </meta>
        <meta name="type">bel</meta>
        <meta name="subtype">routing</meta>
    </metadata>
</mux>
```

Output after:

```xml
<mux input="COMMON_SLICE.AX COMMON_SLICE.A5LUT_O5 COMMON_SLICE.A6LUT_O6" name="AFFMUX1" output="SLICE_FF.D[15]">
    <metadata>
        <meta name="fasm_mux">
            COMMON_SLICE.AX : AFFMUX1.BYP
            COMMON_SLICE.A5LUT_O5 : AFFMUX1.D5
            COMMON_SLICE.A6LUT_O6 : AFFMUX1.D6
        </meta>
        <meta name="type">bel</meta>
        <meta name="subtype">routing</meta>
    </metadata>
</mux>
```

