### PR TITLE
Fix for pack_pattern annotation

### DIFF
--- a/tests/pack_pattern/README.rst
+++ b/tests/pack_pattern/README.rst
@@ -1,0 +1,25 @@
+Pack pattern annotation
++++++++++++++++++++++++
+
+This example shows that v2x prevents annotating a top-level port of a pb_type 
+when a net of that port is forking. This enables using pack patterns, 
+e.g., for LUT to FF connections when the LUT output is also connected to 
+a top-level output port. 
+
+.. symbolator:: pack_pattern.sim.v
+
+.. verilog-diagram:: pack_pattern.sim.v
+   :type: netlistsvg
+   :module: PACK_PATTERN
+
+.. no-license::  pack_pattern.sim.v
+   :language: verilog
+   :caption: pack_pattern.sim.v
+
+.. no-license:: pack_pattern.model.xml
+   :language: xml
+   :caption: pack_pattern.model.xml
+
+.. no-license:: pack_pattern.pb_type.xml
+   :language: xml
+   :caption: pack_pattern.pb_type.xml

--- a/tests/pack_pattern/dff/dff.sim.v
+++ b/tests/pack_pattern/dff/dff.sim.v
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Use of this source code is governed by a ISC-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/ISC
+ *
+ * SPDX-License-Identifier:	ISC
+ */
+
+(* whitebox *)
+module DFF (CLK, D, Q);
+
+	input wire CLK;
+
+	(* SETUP="CLK 10e-12" *)
+	(* HOLD="CLK 10e-12" *)
+	input wire D;
+
+	(* CLK_TO_Q="CLK 10e-12" *)
+	output reg Q;
+	(* ASSOC_CLOCK="CLK" *)
+
+	always @ ( posedge CLK ) begin
+		Q <= D;
+	end
+endmodule

--- a/tests/pack_pattern/dff/golden.model.xml
+++ b/tests/pack_pattern/dff/golden.model.xml
@@ -1,0 +1,12 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <!-- https://docs.verilogtorouting.org/en/latest/tutorials/arch/timing_modeling/#sequential-block-no-internal-paths -->
+  <model name="DFF">
+    <input_ports>
+      <port name="CLK" is_clock="1"/>
+      <port name="D" clock="CLK"/>
+    </input_ports>
+    <output_ports>
+      <port name="Q" clock="CLK"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/pack_pattern/dff/golden.pb_type.xml
+++ b/tests/pack_pattern/dff/golden.pb_type.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="DFF">
+  <blif_model>.subckt DFF</blif_model>
+  <clock name="CLK" num_pins="1"/>
+  <input name="D" num_pins="1"/>
+  <output name="Q" num_pins="1"/>
+  <T_setup port="D" clock="CLK" value="10e-12"/>
+  <T_hold port="D" clock="CLK" value="10e-12"/>
+  <T_clock_to_Q port="Q" clock="CLK" max="10e-12"/>
+</pb_type>

--- a/tests/pack_pattern/golden.model.xml
+++ b/tests/pack_pattern/golden.model.xml
@@ -1,0 +1,4 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <xi:include href="dff/dff.model.xml" xpointer="xpointer(models/child::node())"/>
+  <xi:include href="lut/lut4.model.xml" xpointer="xpointer(models/child::node())"/>
+</models>

--- a/tests/pack_pattern/golden.pb_type.xml
+++ b/tests/pack_pattern/golden.pb_type.xml
@@ -1,0 +1,53 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" num_pb="1" name="PACK_PATTERN">
+  <clock name="CLK" num_pins="1"/>
+  <input name="LUT_IN" num_pins="4"/>
+  <output name="DFF_OUT" num_pins="1"/>
+  <output name="LUT_OUT" num_pins="1"/>
+  <pb_type num_pb="1" name="dff">
+    <!--old_name DFF-->
+    <xi:include href="dff/dff.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+  </pb_type>
+  <pb_type num_pb="1" name="lut">
+    <!--old_name LUT4-->
+    <xi:include href="lut/lut4.pb_type.xml" xpointer="xpointer(pb_type/child::node())"/>
+  </pb_type>
+  <interconnect>
+    <direct>
+      <port name="CLK" type="input"/>
+      <port name="CLK" type="output" from="dff"/>
+    </direct>
+    <direct>
+      <port name="O" type="input" from="lut"/>
+      <port name="LUT_OUT" type="output"/>
+    </direct>
+    <direct>
+      <port name="O" type="input" from="lut"/>
+      <port name="D" type="output" from="dff"/>
+      <pack_pattern name="00000000000000000000000000000001" type="pack">
+        <port name="O" type="input" from="lut"/>
+        <port name="D" type="output" from="dff"/>
+      </pack_pattern>
+    </direct>
+    <direct>
+      <port name="Q" type="input" from="dff"/>
+      <port name="DFF_OUT" type="output"/>
+    </direct>
+    <direct>
+      <port name="LUT_IN[0]" type="input"/>
+      <port name="I[0]" type="output" from="lut"/>
+    </direct>
+    <direct>
+      <port name="LUT_IN[1]" type="input"/>
+      <port name="I[1]" type="output" from="lut"/>
+    </direct>
+    <direct>
+      <port name="LUT_IN[2]" type="input"/>
+      <port name="I[2]" type="output" from="lut"/>
+    </direct>
+    <direct>
+      <port name="LUT_IN[3]" type="input"/>
+      <port name="I[3]" type="output" from="lut"/>
+    </direct>
+  </interconnect>
+</pb_type>

--- a/tests/pack_pattern/lut/golden.model.xml
+++ b/tests/pack_pattern/lut/golden.model.xml
@@ -1,0 +1,10 @@
+<models xmlns:xi="http://www.w3.org/2001/XInclude">
+  <model name="LUT4">
+    <input_ports>
+      <port combinational_sink_ports="O" name="I"/>
+    </input_ports>
+    <output_ports>
+      <port name="O"/>
+    </output_ports>
+  </model>
+</models>

--- a/tests/pack_pattern/lut/golden.pb_type.xml
+++ b/tests/pack_pattern/lut/golden.pb_type.xml
@@ -1,0 +1,9 @@
+<?xml version='1.0' encoding='utf-8'?>
+<pb_type xmlns:xi="http://www.w3.org/2001/XInclude" name="LUT4" num_pb="1">
+  <blif_model>.subckt LUT4</blif_model>
+  <input name="I" num_pins="4"/>
+  <output name="O" num_pins="1"/>
+  <delay_matrix in_port="LUT4.I" out_port="LUT4.O" type="max">
+30e-12 20e-12 11e-12 3e-12
+</delay_matrix>
+</pb_type>

--- a/tests/pack_pattern/lut/lut4.sim.v
+++ b/tests/pack_pattern/lut/lut4.sim.v
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Use of this source code is governed by a ISC-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/ISC
+ *
+ * SPDX-License-Identifier:	ISC
+ */
+
+(* whitebox *)
+module LUT4 (I, O);
+	input wire [3:0] I;
+	(* DELAY_MATRIX_I="30e-12 20e-12 11e-12 3e-12" *)
+	output wire O;
+
+	localparam INIT = 16'h0000;
+	assign O = INIT[I];
+endmodule

--- a/tests/pack_pattern/pack_pattern.sim.v
+++ b/tests/pack_pattern/pack_pattern.sim.v
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2020  The SymbiFlow Authors.
+ *
+ * Use of this source code is governed by a ISC-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/ISC
+ *
+ * SPDX-License-Identifier:	ISC
+ */
+
+`include "lut/lut4.sim.v"
+`include "dff/dff.sim.v"
+
+module PACK_PATTERN (
+    CLK,
+    LUT_IN,
+    LUT_OUT,
+    DFF_OUT
+);
+    input wire CLK;
+    input wire [3:0] LUT_IN;
+
+    output wire LUT_OUT;
+    output wire DFF_OUT;
+
+    (* pack *)
+    wire w;
+
+    LUT4 lut (.I(LUT_IN), .O(w));
+    DFF dff (.CLK(CLK), .D(w), .Q(DFF_OUT));
+
+    assign LUT_OUT = w;
+endmodule

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -629,12 +629,25 @@ def make_container_pb(
     for (driver_cell, driver_pin), sinks in interconn.items():
         if driver_cell in routing_cells:
             continue
-        for (sink_cell, sink_pin), path_attr in sinks:
-            if sink_cell in routing_cells:
-                continue
+
+        non_routing_sinks = [(sink, path_attr) for sink, path_attr in sinks
+                             if sink[0] not in routing_cells]
+
+        is_forking = len(non_routing_sinks) > 1
+
+        for (sink_cell, sink_pin), path_attr in non_routing_sinks:
+            attrs = dict(**path_attr)
+
+            # If a net forks remove pack pattern annotations from the branch
+            # that goes to an output port of the pb_type
+            if is_forking and sink_cell is None:
+                for a in ["pack", "PACK"]:
+                    if a in attrs:
+                        del attrs[a]
+
             make_direct_conn(
                 ic_xml, (normalize_pb_name(driver_cell), driver_pin),
-                (normalize_pb_name(sink_cell), sink_pin), path_attr
+                (normalize_pb_name(sink_cell), sink_pin), attrs
             )
 
     # Generate the mux interconnects

--- a/v2x/vlog_to_pbtype.py
+++ b/v2x/vlog_to_pbtype.py
@@ -226,8 +226,9 @@ def net_and_pin_attrs(yj, mod, driver: CellPin, sink: CellPin, netid: int):
         potential_attrs.append(filter_src(smod.port_attrs(sink_pin)))
 
     net_attrs = filter_src(mod.net_attrs_by_netid(netid))
-    copy_attrs(net_attrs, potential_attrs)
-    return net_attrs
+    net_attrs_norm = {k.lower(): v for k, v in net_attrs.items()}
+    copy_attrs(net_attrs_norm, potential_attrs)
+    return net_attrs_norm
 
 
 def make_direct_conn(
@@ -641,9 +642,9 @@ def make_container_pb(
             # If a net forks remove pack pattern annotations from the branch
             # that goes to an output port of the pb_type
             if is_forking and sink_cell is None:
-                for a in ["pack", "PACK"]:
-                    if a in attrs:
-                        del attrs[a]
+
+                if "pack" in attrs:
+                    del attrs["pack"]
 
             make_direct_conn(
                 ic_xml, (normalize_pb_name(driver_cell), driver_pin),


### PR DESCRIPTION
This PR prevents V2X from annotating a top-level port of a pb_type when a net of that port is forking. This allows to use pack patterns eg. for LUT to FF connections when the LUT output is also connected to a top-level output port.