### PR TITLE
license: fix ISC license header for some scripts

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC
 
 set -ex
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -21,3 +21,6 @@ pycairo
 
 # V2X
 -e ../
+
+# XML utils
+git+https://github.com/SymbiFlow/vtr-xml-utils.git#egg=vtr-xml-utils

--- a/v2x/__init__.py
+++ b/v2x/__init__.py
@@ -1,2 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC

--- a/v2x/lib/__init__.py
+++ b/v2x/lib/__init__.py
@@ -1,2 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC

--- a/v2x/xmlinc/__init__.py
+++ b/v2x/xmlinc/__init__.py
@@ -1,2 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC

--- a/v2x/yosys/__init__.py
+++ b/v2x/yosys/__init__.py
@@ -1,2 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# Copyright (C) 2020  The SymbiFlow Authors.
+#
+# Use of this source code is governed by a ISC-style
+# license that can be found in the LICENSE file or at
+# https://opensource.org/licenses/ISC
+#
+# SPDX-License-Identifier:	ISC


### PR DESCRIPTION
Signed-off-by: Alessandro Comodi <acomodi@antmicro.com>

Some license header file were missing, causing master to fail on the forked repo: https://github.com/antmicro/python-symbiflow-v2x/runs/1594323973.

This PR adds the missing license header files