### PR TITLE
Remove usage of `distutils`

### DIFF
--- a/tests/test_v2x.py
+++ b/tests/test_v2x.py
@@ -28,7 +28,7 @@ from v2x.mux_gen import mux_gen
 
 from vtr_xml_utils import convert
 
-from distutils.dir_util import copy_tree
+from shutil import copytree
 
 TEST_TMP_SUFFIX = 'build/'
 
@@ -49,7 +49,7 @@ def prepare_files():
         s = os.path.join(scriptdir, tdir)
         d = os.path.join(testdir, tdir)
         if os.path.isdir(s):
-            copy_tree(s, d, update=1)
+            copytree(s, d, dirs_exist_ok=True)
 
     # Generate muxes/routing for tests/muxes model
     mux_gen(outdir=os.path.join(testdir, 'muxes/routing'),


### PR DESCRIPTION
`distutils` was removed in Python 3.12, causing `v2x`'s tests to fail when attempting to use it.

I replaced it with an equivalent function from `shutil`. As far as I can tell, the old `update=1` was just an optimisation, so I think it's fine that there's no equivalent?